### PR TITLE
updated lineup augmentation and optimization

### DIFF
--- a/R/augment_unique_lineups.R
+++ b/R/augment_unique_lineups.R
@@ -12,24 +12,35 @@ augment_unique_lineups <- function(unique_lineup_object,
                                    outcome_object) {
   
   outcome_positions <- names(outcome_object)
+  
   lu_outcome <- do.call(rbind, outcome_object) %>%
     dplyr::group_by(uid) %>%
     dplyr::filter(row_number() == 1) %>%
     dplyr::ungroup() %>%
-    dplyr::select(uid, game_id, outcome)
+    dplyr::select(uid, tm, game_id, outcome)
+  
   projection_mat <- matrix(nrow = nrow(unique_lineup_object), ncol = ncol(unique_lineup_object))
+  
   game_mat <- matrix(nrow = nrow(unique_lineup_object), ncol = ncol(unique_lineup_object))
+  
+  tm_mat <- matrix(nrow = nrow(unique_lineup_object), ncol = ncol(unique_lineup_object))
+  
   for (i in 1:ncol(unique_lineup_object)) {
     uid_column <- data.frame(uid = unique_lineup_object[, i])
     uid_outcome <- dplyr::inner_join(uid_column, lu_outcome, by = "uid")
     projection_mat[, i] <- uid_outcome$outcome
     game_mat[, i] <- uid_outcome$game_id
+    tm_mat[, i] <- uid_outcome$tm
   }
   
   projections <- rowSums(projection_mat)
   unique_games <- as.numeric(apply(game_mat, 1, function(x) length(unique(x))))
+  max_players_per_team <- as.numeric(apply(tm_mat, 1, function(x) max(table(x))))
   
-  output_df <- data.frame(unique_lineup_object, outcome = projections, games = unique_games)
+  team_counter <- matrix(ncol = length(unique(lu_outcome$tm))) %>% as.data.frame()
+  names(team_counter) <- unique(lu_outcome$tm)
+  
+  output_df <- data.frame(unique_lineup_object, outcome = projections, games = unique_games, max_team_rep = max_players_per_team)
   
   return(output_df)
   

--- a/R/optimize_lineups.R
+++ b/R/optimize_lineups.R
@@ -1,9 +1,11 @@
 #' Optimize the lineups
 #' 
 #' @param unique_lineup_object List of unique objects from \code{make_unique_lineups}
-#' @param n_lineups The number of lineups to save (default = 20)
-#' @param max_exposure The max percentage of lineups in which a single player can be included (default = 65)
-#' @param limit_search A value used to reduce search space (default 5000)
+#' @param n_lineups The number of lineups to save
+#' @param max_exposure The max percentage of lineups in which a single player can be included
+#' @param min_games A value indicating the minimum number of games to be represented on a lineups
+#' @param max_teamrep A value indicating the maximum number of players that can be on a single team
+#' @param limit_search A value used to reduce search space
 #' 
 #' @return List of optimal lineups
 #' 
@@ -12,18 +14,22 @@
 optimize_lineups <- function(unique_lineup_object,
                              n_lineups, 
                              max_exposure,
+                             min_games = 2,
+                             max_teamrep = 4,
                              limit_search = nrow(unique_lineup_object)) {
 
   lineup_id <- 1:nrow(unique_lineup_object)
   unique_lineup_object$lineupid <- lineup_id
   
   final_lineups <- unique_lineup_object %>%
-    dplyr::filter(games > 1) %>%
+    dplyr::filter(games >= min_games) %>%
+    dplyr::filter(max_team_rep <= max_teamrep) %>%
     dplyr::arrange(-outcome) %>%
     dplyr::filter(row_number() <= n_lineups)
   
   remaining_lineups <- unique_lineup_object %>%
-    dplyr::filter(games > 1) %>%
+    dplyr::filter(games >= min_games) %>%
+    dplyr::filter(max_team_rep <= max_teamrep) %>%
     dplyr::filter(lineupid <= limit_search) %>%
     dplyr::filter(!(lineupid %in% unique(final_lineups$lineupid))) %>%
     dplyr::arrange(-outcome)


### PR DESCRIPTION
 updated lineup augmentation and optimization to enable enforcement of fanduel lineup rules, in this case the maximum number of players from a single nba team that can be represented across a single lineup